### PR TITLE
refactor(organizer): unify create and edit event forms into a single modal and fix ticket page

### DIFF
--- a/frontend/src/components/organizer/EventForm.vue
+++ b/frontend/src/components/organizer/EventForm.vue
@@ -1,0 +1,3 @@
+<template>
+
+</template>

--- a/frontend/src/pages/organizer/Ticket.vue
+++ b/frontend/src/pages/organizer/Ticket.vue
@@ -47,10 +47,6 @@
         </CardContent>
       </Card>
 
-      <div v-if="tickets.length === 0" class="text-gray-500">
-        No tickets available.
-      </div>
-
       <!-- Modal: Create/Edit -->
       <Dialog :open="showFormModal" @update:open="showFormModal = $event">
         <DialogContent class="sm:max-w-md">
@@ -90,7 +86,7 @@
           </div>
           <DialogFooter>
             <Button variant="outline" @click="showFormModal = false" class="cursor-pointer">Cancel</Button>
-            <Button
+            <Button :disabled="isEditing ? ticketStore.updateState.loading : ticketStore.createState.loading"
               :class="isEditing ? 'bg-slate-600 hover:bg-slate-700 cursor-pointer' : 'bg-purple-600 hover:bg-purple-700 cursor-pointer'"
               @click="handleSubmitTicket">
               {{ isEditing ? "Update" : "Create" }}
@@ -105,7 +101,7 @@
           <DialogHeader>
             <DialogTitle>Delete Ticket</DialogTitle>
             <DialogDescription>
-              Are you sure you want to delete <strong>{{ selectedTicket?.name }}</strong>?
+              Are you sure you want to delete <strong>{{ selectedTicket?.name }}</strong>? This action cannot be undone.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -200,6 +196,11 @@ function openEditModal(ticket: any) {
   showFormModal.value = true;
 }
 
+function openDeleteModal(ticket: any) {
+  selectedTicket.value = ticket;
+  showDeleteModal.value = true;
+}
+
 async function handleSubmitTicket() {
   try {
     const formData = new FormData();
@@ -228,11 +229,6 @@ async function handleSubmitTicket() {
     })
     console.error(`Failed to ${isEditing.value ? 'update' : 'create'} ticket`, err);
   }
-}
-
-function openDeleteModal(ticket: any) {
-  selectedTicket.value = ticket;
-  showDeleteModal.value = true;
 }
 
 async function confirmDelteTicket() {


### PR DESCRIPTION
- Replaced separate create/edit modals with a shared form using reactive state
- Added isEditing flag and selectedEvent reference to control modal behavior
- Simplified event form logic for better reusability and consistency
- Fix Ticket page
- Create Event Form component file to separate later